### PR TITLE
[PR] Adding a dedicated Joystick component

### DIFF
--- a/Editor/Joysticks/DynamicJoystickEditor.cs
+++ b/Editor/Joysticks/DynamicJoystickEditor.cs
@@ -1,0 +1,37 @@
+﻿using CineGame.MobileComponents;
+using UnityEditor;
+using UnityEngine;
+
+namespace CineGameEditor.MobileComponents
+{
+    [CustomEditor(typeof(DynamicJoystick))]
+    public class DynamicJoystickEditor : JoystickEditor
+    {
+        private SerializedProperty moveThreshold;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            moveThreshold = serializedObject.FindProperty("moveThreshold");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            if (background != null)
+            {
+                RectTransform backgroundRect = (RectTransform)background.objectReferenceValue;
+                backgroundRect.anchorMax = Vector2.zero;
+                backgroundRect.anchorMin = Vector2.zero;
+                backgroundRect.pivot = center;
+            }
+        }
+
+        protected override void DrawValues()
+        {
+            base.DrawValues();
+            EditorGUILayout.PropertyField(moveThreshold, new GUIContent("Move Threshold", "The distance away from the center input has to be before the joystick begins to move."));
+        }
+    }
+}

--- a/Editor/Joysticks/FloatingJoystickEditor.cs
+++ b/Editor/Joysticks/FloatingJoystickEditor.cs
@@ -1,0 +1,23 @@
+﻿using CineGame.MobileComponents;
+using UnityEditor;
+using UnityEngine;
+
+namespace CineGameEditor.MobileComponents
+{
+    [CustomEditor(typeof(FloatingJoystick))]
+    public class FloatingJoystickEditor : JoystickEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            if (background.objectReferenceValue != null)
+            {
+                RectTransform backgroundRect = (RectTransform)background.objectReferenceValue;
+                backgroundRect.anchorMax = Vector2.zero;
+                backgroundRect.anchorMin = Vector2.zero;
+                backgroundRect.pivot = center;
+            }
+        }
+    }
+}

--- a/Editor/Joysticks/JoystickEditor.cs
+++ b/Editor/Joysticks/JoystickEditor.cs
@@ -1,0 +1,69 @@
+﻿using CineGame.MobileComponents;
+using UnityEditor;
+using UnityEngine;
+
+namespace CineGameEditor.MobileComponents
+{
+    [CustomEditor(typeof(Joystick), true)]
+    public class JoystickEditor : Editor
+    {
+        private SerializedProperty dragKey;
+        private SerializedProperty handleRange;
+        private SerializedProperty deadZone;
+        private SerializedProperty axisOptions;
+        private SerializedProperty snapX;
+        private SerializedProperty snapY;
+        protected SerializedProperty background;
+        private SerializedProperty handle;
+
+        protected Vector2 center = new Vector2(0.5f, 0.5f);
+
+        protected virtual void OnEnable()
+        {
+            dragKey = serializedObject.FindProperty("DragKey");
+            handleRange = serializedObject.FindProperty("handleRange");
+            deadZone = serializedObject.FindProperty("deadZone");
+            axisOptions = serializedObject.FindProperty("axisOptions");
+            snapX = serializedObject.FindProperty("snapX");
+            snapY = serializedObject.FindProperty("snapY");
+            background = serializedObject.FindProperty("background");
+            handle = serializedObject.FindProperty("handle");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            DrawValues();
+            EditorGUILayout.Space();
+            DrawComponents();
+
+            serializedObject.ApplyModifiedProperties();
+
+            if (handle.objectReferenceValue != null)
+            {
+                RectTransform handleRect = (RectTransform)handle.objectReferenceValue;
+                handleRect.anchorMax = center;
+                handleRect.anchorMin = center;
+                handleRect.pivot = center;
+                handleRect.anchoredPosition = Vector2.zero;
+            }
+        }
+
+        protected virtual void DrawValues()
+        {
+            EditorGUILayout.PropertyField(dragKey, new GUIContent("Drag Key", "The key that the Host will listen for to get axis values."));
+            EditorGUILayout.PropertyField(handleRange, new GUIContent("Handle Range", "The distance the visual handle can move from the center of the joystick."));
+            EditorGUILayout.PropertyField(deadZone, new GUIContent("Dead Zone", "The distance away from the center input has to be before registering."));
+            EditorGUILayout.PropertyField(axisOptions, new GUIContent("Axis Options", "Which axes the joystick uses."));
+            EditorGUILayout.PropertyField(snapX, new GUIContent("Snap X", "Snap the horizontal input to a whole value."));
+            EditorGUILayout.PropertyField(snapY, new GUIContent("Snap Y", "Snap the vertical input to a whole value."));
+        }
+
+        protected virtual void DrawComponents()
+        {
+            EditorGUILayout.ObjectField(background, new GUIContent("Background", "The background's RectTransform component."));
+            EditorGUILayout.ObjectField(handle, new GUIContent("Handle", "The handle's RectTransform component."));
+        }
+    }
+}

--- a/Editor/Joysticks/VariableJoystickEditor.cs
+++ b/Editor/Joysticks/VariableJoystickEditor.cs
@@ -1,0 +1,38 @@
+﻿using CineGame.MobileComponents;
+using UnityEditor;
+using UnityEngine;
+
+namespace CineGameEditor.MobileComponents
+{
+    [CustomEditor(typeof(VariableJoystick))]
+    public class VariableJoystickEditor : JoystickEditor
+    {
+        private SerializedProperty moveThreshold;
+        private SerializedProperty joystickType;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            moveThreshold = serializedObject.FindProperty("moveThreshold");
+            joystickType = serializedObject.FindProperty("joystickType");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            if (background.objectReferenceValue != null)
+            {
+                RectTransform backgroundRect = (RectTransform)background.objectReferenceValue;
+                backgroundRect.pivot = center;
+            }
+        }
+
+        protected override void DrawValues()
+        {
+            base.DrawValues();
+            EditorGUILayout.PropertyField(moveThreshold, new GUIContent("Move Threshold", "The distance away from the center input has to be before the joystick begins to move."));
+            EditorGUILayout.PropertyField(joystickType, new GUIContent("Joystick Type", "The type of joystick the variable joystick is current using."));
+        }
+    }
+}

--- a/Runtime/JoystickComponent.cs
+++ b/Runtime/JoystickComponent.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CineGame.MobileComponents
+{
+    public class JoystickComponent : MonoBehaviour
+    {
+        public VariableJoystick JoystickPrefab;
+        public JoystickType Type = JoystickType.Fixed;
+        public AxisOptions AxisOption = AxisOptions.Both;
+        public AxisSnap SnapType = AxisSnap.None;
+        public Sprite AxisSpriteBoth;
+        public Sprite AxisSpriteHorizontal;
+        public Sprite AxisSpriteVertical;
+
+        public enum AxisSnap { None, X, Y }
+
+        private void Awake()
+        {
+            SetAxisType(Type);
+            SetAxisOptions(AxisOption);
+            switch (SnapType)
+            {
+                case AxisSnap.None: SnapX(false); SnapY(false); break;
+                case AxisSnap.X: SnapX(true); SnapY(false); break;
+                case AxisSnap.Y: SnapX(false); SnapY(true); break;
+            }
+        }
+
+        public void SetAxisType(JoystickType type) => JoystickPrefab.SetMode(type);
+
+        public void SetAxisOptions(AxisOptions type)
+        {
+            Image background = JoystickPrefab.background.GetComponent<Image>();
+            JoystickPrefab.AxisOptions = type;
+            background.sprite = type switch
+            {
+                AxisOptions.Both => AxisSpriteBoth,
+                AxisOptions.Horizontal => AxisSpriteHorizontal,
+                AxisOptions.Vertical => AxisSpriteVertical,
+                _ => throw new ArgumentException($"Unknown AxisOptions Type '{Enum.GetName(typeof(AxisOptions), type)}'"),
+            };
+        }
+
+        public void SnapX(bool value) => JoystickPrefab.SnapX = value;
+        public void SnapY(bool value) => JoystickPrefab.SnapY = value;
+    }
+}

--- a/Runtime/Joysticks/DynamicJoystick.cs
+++ b/Runtime/Joysticks/DynamicJoystick.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace CineGame.MobileComponents
+{
+    public class DynamicJoystick : Joystick
+    {
+        public float MoveThreshold { get { return moveThreshold; } set { moveThreshold = Mathf.Abs(value); } }
+
+        [SerializeField] private float moveThreshold = 1;
+
+        protected override void Start()
+        {
+            MoveThreshold = moveThreshold;
+            base.Start();
+        }
+
+        public override void OnPointerDown(PointerEventData eventData)
+        {
+            background.anchoredPosition = ScreenPointToAnchoredPosition(eventData.position);
+            base.OnPointerDown(eventData);
+        }
+
+        public override void OnPointerUp(PointerEventData eventData) => base.OnPointerUp(eventData);
+
+        protected override void HandleInput(float magnitude, Vector2 normalised, Vector2 radius, Camera cam)
+        {
+            if (magnitude > moveThreshold)
+            {
+                Vector2 difference = normalised * (magnitude - moveThreshold) * radius;
+                background.anchoredPosition += difference;
+            }
+            base.HandleInput(magnitude, normalised, radius, cam);
+        }
+    }
+}

--- a/Runtime/Joysticks/FixedJoystick.cs
+++ b/Runtime/Joysticks/FixedJoystick.cs
@@ -1,0 +1,4 @@
+﻿namespace CineGame.MobileComponents
+{
+    public class FixedJoystick : Joystick { }
+}

--- a/Runtime/Joysticks/FloatingJoystick.cs
+++ b/Runtime/Joysticks/FloatingJoystick.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine.EventSystems;
+
+namespace CineGame.MobileComponents
+{
+    public class FloatingJoystick : Joystick
+    {
+        protected override void Start() => base.Start();
+
+        public override void OnPointerDown(PointerEventData eventData)
+        {
+            background.anchoredPosition = ScreenPointToAnchoredPosition(eventData.position);
+            base.OnPointerDown(eventData);
+        }
+
+        public override void OnPointerUp(PointerEventData eventData) => base.OnPointerUp(eventData);
+    }
+}

--- a/Runtime/Joysticks/Joystick.cs
+++ b/Runtime/Joysticks/Joystick.cs
@@ -1,0 +1,154 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace CineGame.MobileComponents
+{
+    public class Joystick : ReplicatedComponent, IPointerDownHandler, IDragHandler, IPointerUpHandler
+    {
+        public string DragKey = "OnHandleDrag";
+
+        public float Horizontal { get { return (snapX) ? SnapFloat(input.x, AxisOptions.Horizontal) : input.x; } }
+        public float Vertical { get { return (snapY) ? SnapFloat(input.y, AxisOptions.Vertical) : input.y; } }
+        public Vector2 Direction { get { return new Vector2(Horizontal, Vertical); } }
+
+        public float HandleRange
+        {
+            get { return handleRange; }
+            set { handleRange = Mathf.Abs(value); }
+        }
+
+        public float DeadZone
+        {
+            get { return deadZone; }
+            set { deadZone = Mathf.Abs(value); }
+        }
+
+        public AxisOptions AxisOptions { get { return AxisOptions; } set { axisOptions = value; } }
+        public bool SnapX { get { return snapX; } set { snapX = value; } }
+        public bool SnapY { get { return snapY; } set { snapY = value; } }
+
+        [SerializeField] private float handleRange = 1;
+        [SerializeField] private float deadZone = 0;
+        [SerializeField] private AxisOptions axisOptions = AxisOptions.Both;
+        [SerializeField] private bool snapX = false;
+        [SerializeField] private bool snapY = false;
+
+        [SerializeField] internal RectTransform background = null;
+        [SerializeField] private RectTransform handle = null;
+        private RectTransform baseRect = null;
+
+        private Canvas canvas;
+        private Camera cam;
+
+        private Vector2 input = Vector2.zero;
+
+        protected virtual void Start()
+        {
+            HandleRange = handleRange;
+            DeadZone = deadZone;
+            baseRect = GetComponent<RectTransform>();
+            canvas = GetComponentInParent<Canvas>();
+            if (canvas == null)
+                Debug.LogError("The Joystick is not placed inside a canvas");
+
+            Vector2 center = new Vector2(0.5f, 0.5f);
+            background.pivot = center;
+            handle.anchorMin = center;
+            handle.anchorMax = center;
+            handle.pivot = center;
+            handle.anchoredPosition = Vector2.zero;
+        }
+
+        public virtual void OnPointerDown(PointerEventData eventData) => OnDrag(eventData);
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            cam = null;
+            if (canvas.renderMode == RenderMode.ScreenSpaceCamera)
+                cam = canvas.worldCamera;
+
+            Vector2 position = RectTransformUtility.WorldToScreenPoint(cam, background.position);
+            Vector2 radius = background.sizeDelta / 2;
+            input = (eventData.position - position) / (radius * canvas.scaleFactor);
+            FormatInput();
+            HandleInput(input.magnitude, input.normalized, radius, cam);
+            handle.anchoredPosition = input * radius * handleRange;
+        }
+
+        protected virtual void HandleInput(float magnitude, Vector2 normalised, Vector2 radius, Camera cam)
+        {
+            if (magnitude > deadZone)
+            {
+                if (magnitude > 1)
+                    input = normalised;
+            }
+            else
+            {
+                input = Vector2.zero;
+            }
+            Send(DragKey, new float[2] { Direction.x, Direction.y });
+        }
+
+        private void FormatInput()
+        {
+            if (axisOptions == AxisOptions.Horizontal)
+                input = new Vector2(input.x, 0f);
+            else if (axisOptions == AxisOptions.Vertical)
+                input = new Vector2(0f, input.y);
+        }
+
+        private float SnapFloat(float value, AxisOptions snapAxis)
+        {
+            if (value == 0)
+                return value;
+
+            if (axisOptions == AxisOptions.Both)
+            {
+                float angle = Vector2.Angle(input, Vector2.up);
+                if (snapAxis == AxisOptions.Horizontal)
+                {
+                    if (angle < 22.5f || angle > 157.5f)
+                        return 0;
+                    else
+                        return (value > 0) ? 1 : -1;
+                }
+                else if (snapAxis == AxisOptions.Vertical)
+                {
+                    if (angle > 67.5f && angle < 112.5f)
+                        return 0;
+                    else
+                        return (value > 0) ? 1 : -1;
+                }
+                return value;
+            }
+            else
+            {
+                if (value > 0)
+                    return 1;
+                if (value < 0)
+                    return -1;
+            }
+            return 0;
+        }
+
+        public virtual void OnPointerUp(PointerEventData eventData)
+        {
+            input = Vector2.zero;
+            handle.anchoredPosition = Vector2.zero;
+            Send(DragKey, new float[2] { Direction.x, Direction.y });
+        }
+
+        protected Vector2 ScreenPointToAnchoredPosition(Vector2 screenPosition)
+        {
+            Vector2 localPoint = Vector2.zero;
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(baseRect, screenPosition, cam, out localPoint))
+            {
+                Vector2 pivotOffset = baseRect.pivot * baseRect.sizeDelta;
+                return localPoint - (background.anchorMax * baseRect.sizeDelta) + pivotOffset;
+            }
+            return Vector2.zero;
+        }
+    }
+
+    public enum AxisOptions { Both, Horizontal, Vertical }
+}

--- a/Runtime/Joysticks/VariableJoystick.cs
+++ b/Runtime/Joysticks/VariableJoystick.cs
@@ -1,0 +1,54 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace CineGame.MobileComponents
+{
+    public class VariableJoystick : Joystick
+    {
+        public float MoveThreshold { get { return moveThreshold; } set { moveThreshold = Mathf.Abs(value); } }
+
+        [SerializeField] private float moveThreshold = 1;
+        [SerializeField] private JoystickType joystickType = JoystickType.Fixed;
+
+        private Vector2 fixedPosition = Vector2.zero;
+
+        public void SetMode(JoystickType joystickType)
+        {
+            this.joystickType = joystickType;
+            if (joystickType == JoystickType.Fixed)
+            {
+                background.anchoredPosition = fixedPosition;
+            }
+        }
+
+        protected override void Start()
+        {
+            base.Start();
+            fixedPosition = background.anchoredPosition;
+            SetMode(joystickType);
+        }
+
+        public override void OnPointerDown(PointerEventData eventData)
+        {
+            if (joystickType != JoystickType.Fixed)
+            {
+                background.anchoredPosition = ScreenPointToAnchoredPosition(eventData.position);
+            }
+            base.OnPointerDown(eventData);
+        }
+
+        public override void OnPointerUp(PointerEventData eventData) => base.OnPointerUp(eventData);
+
+        protected override void HandleInput(float magnitude, Vector2 normalised, Vector2 radius, Camera cam)
+        {
+            if (joystickType == JoystickType.Dynamic && magnitude > moveThreshold)
+            {
+                Vector2 difference = normalised * (magnitude - moveThreshold) * radius;
+                background.anchoredPosition += difference;
+            }
+            base.HandleInput(magnitude, normalised, radius, cam);
+        }
+    }
+
+    public enum JoystickType { Fixed, Floating, Dynamic }
+}


### PR DESCRIPTION
The original asset can be found here: https://assetstore.unity.com/packages/tools/input-management/joystick-pack-107631

I found this asset for free on the Unity Asset store and adjusted it to fit in the CinemaTaztic framework. It works in editor as expected, but it's impossible to test on the client until it's added to the SDK. The current drag-and-drop component, while functional, has some undesirable aspects to it when we need it for a virtual joystick.

For one, we get values from 0-1 where the middle is defined as 0.5,0.5 when it's expected to get values from -1 to 1 with a middle of 0,0. The current approach adds unnecessary complexity on the host side as we have to adjust for the values coming in.
There will undoubedtly also be many who can use a dedicated joystick component, not just us.