### PR TITLE
Editor script for creating new SpriteAtlas based on multiple selection

### DIFF
--- a/Editor/SpriteAtlasCreator.cs
+++ b/Editor/SpriteAtlasCreator.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.U2D;
+using UnityEngine.U2D;
+
+internal static class SpriteAtlasCreator {
+
+	/// <summary>
+	/// Add a menu item for creating a new SpriteAtlas asset in the project based on multiple sprite textures
+	/// </summary>
+	[MenuItem ("Assets/CineGame/Create SpriteAtlas")]
+	static void PackSpriteAtlas () {
+		if (EditorSettings.spritePackerMode == SpritePackerMode.Disabled) {
+			var sel = EditorUtility.DisplayDialogComplex ("Sprite Atlas Creator", "Sprite packing is disabled. Do you want to enable it now?", "Enable always", "No thanks", "Enable buildtime");
+			if (sel != 1) {
+				EditorSettings.spritePackerMode = sel == 0 ? SpritePackerMode.AlwaysOnAtlas : SpritePackerMode.BuildTimeOnlyAtlas;
+			}
+		}
+
+		var guids = Selection.assetGUIDs;
+		if (guids.Length > 0) {
+			SpriteAtlas sa = new SpriteAtlas ();
+			var textures = new List<UnityEngine.Object> ();
+			foreach (var guid in guids) {
+				var assetPath = AssetDatabase.GUIDToAssetPath (guid);
+				textures.Add (AssetDatabase.LoadMainAssetAtPath (assetPath));
+			}
+			sa.Add (textures.ToArray ());
+			var path = Path.Combine (Path.GetDirectoryName (AssetDatabase.GUIDToAssetPath (guids [0])), "New SpriteAtlas.spriteatlas");
+			ProjectWindowUtil.CreateAsset (sa, path);
+		}
+	}
+
+	/// <summary>
+	/// Only enable menu item if valid sprite textures are selected
+	/// </summary>
+	[MenuItem ("Assets/CineGame/Create SpriteAtlas", true)]
+	static bool ValidatePackSpriteAtlas () {
+		var guids = Selection.assetGUIDs;
+		if (guids.Length == 0)
+			return false;
+		foreach (var guid in guids) {
+			var assetPath = AssetDatabase.GUIDToAssetPath (guid);
+			TextureImporter textureImporter = AssetImporter.GetAtPath (assetPath) as TextureImporter;
+			if (textureImporter == null || textureImporter.textureType != TextureImporterType.Sprite) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/Editor/SpriteAtlasCreator.cs.meta
+++ b/Editor/SpriteAtlasCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6301814717594410cbf1bcaa43a873ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The new SpriteAtlas feature in Unity lacks the ability to create a SpriteAtlas from multiple selected sprites. This script provides that feature. Closes #5 