### PR TITLE
Feature: Layout animator

### DIFF
--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.6.3.0")]
+[assembly: AssemblyVersion ("1.7.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Editor/CineGameBuild.cs
+++ b/Editor/CineGameBuild.cs
@@ -1164,6 +1164,7 @@ namespace CineGameEditor.MobileComponents {
 			{ "GravityComponent.cs", "a5f37167862804f4085906d19efb4f6d" },
 			{ "GyroComponent.cs", "4b2e7470ca5cd4ba28ba7ca9f9432a98" },
 			{ "JoystickComponent.cs", "e12223f1cfe254b5fa8b051b88c642a2" },
+			{ "LayoutAnimator.cs", "c11e6438a22d14a119c26a450b02d98e" },
 			{ "LogicComponent.cs", "cc7fbe9cb65b24476b1426f19a438a63" },
 			{ "LookAt.cs", "93bc52955bb1a40a5aafdaeb32f37cfe" },
 			{ "MaterialProperty.cs", "695b935104058422c99c25a86212e265" },

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.6.3.0")]
+[assembly: AssemblyVersion ("1.7.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Runtime/LayoutAnimator.cs
+++ b/Runtime/LayoutAnimator.cs
@@ -1,0 +1,164 @@
+using UnityEngine;
+using System.Collections.Generic;
+using System.Collections;
+using UnityEngine.UI;
+
+namespace CineGame.MobileComponents {
+
+    [RequireComponent (typeof (CanvasGroup))]
+    [ComponentReference ("Animates a layout group with smooth interpolation of each direct child element. When child elements are reparented or destroyed, the visual representation will smoothly fade or scale out (or both). If you want to add a child element smoothly (like drag-and-drop), invoke the AddElement method")]
+    public class LayoutAnimator : BaseComponent {
+        [Tooltip ("The speed of interpolation. Default is 10")]
+        [Range (1f, 100f)]
+        public float AnimationSpeed = 10f;
+
+        public enum DestroyAnimType {
+            ScaleDown,
+            FadeOut,
+            ScaleAndFade,
+        }
+        [Tooltip ("Which animation to perform when destroying an element")]
+        public DestroyAnimType DestroyAnim = DestroyAnimType.ScaleDown;
+
+        Transform Container;
+        bool bCheckAdded;
+
+        class Tuple {
+            public RectTransform original;
+            public RectTransform animated;
+        }
+
+        readonly HashSet<Transform> TrackedTransforms = new ();
+        readonly List<Tuple> TrackedObjects = new ();
+
+        void Start () {
+            var containerGo = Instantiate (gameObject, transform.parent);
+            Container = containerGo.transform;
+            Destroy (containerGo.GetComponent<LayoutAnimator> ());
+            Destroy (containerGo.GetComponent<LayoutGroup> ());
+            var layoutElement = containerGo.AddComponent<LayoutElement> ();
+            layoutElement.ignoreLayout = true;
+            GetComponent<CanvasGroup> ().alpha = 0f;
+            //var containerGo = new GameObject ("LayoutAnimator_Container");
+            //containerGo.transform.SetParent (GetComponentInParent<Canvas> ().transform);
+            //Container = containerGo.AddComponent<RectTransform> ();
+        }
+
+        void OnDestroy () {
+            Destroy (Container.gameObject);
+        }
+
+        void OnTransformChildrenChanged () {
+            bCheckAdded = true;
+        }
+
+        void LateUpdate () {
+            if (bCheckAdded) {
+                bCheckAdded = false;
+                var num = transform.childCount;
+                for (int i = 0; i < num; i++) {
+                    var t = transform.GetChild (i);
+                    if (TrackedTransforms.Add (t)) {
+                        //new element, lets clone it and track it
+                        var newGameObject = Instantiate (t.gameObject, Container);
+                        TrackedObjects.Add (new Tuple {
+                            original = t.GetComponent<RectTransform> (),
+                            animated = newGameObject.GetComponent<RectTransform> (),
+                        });
+                    }
+                }
+            }
+
+            var e = TrackedObjects.Count;
+            var speed = Time.deltaTime * AnimationSpeed;
+
+            for (int j = 0; j < e; j++) {
+                var t = TrackedObjects [j];
+                if (t.original == null || t.original.parent != transform) {
+                    //original destroyed, destroy animated and remove tuple
+                    StartCoroutine (E_Destroy (t.animated));
+                    TrackedTransforms.Remove (t.original);
+                    TrackedObjects.RemoveAt (j--);
+                    e--;
+                    continue;
+                }
+                var pos = t.animated.position;
+                var dest = t.original.position;
+                t.animated.position = Vector3.Lerp (pos, dest, speed);
+                var size = t.animated.sizeDelta;
+                var sdest = t.original.sizeDelta;
+                t.animated.sizeDelta = Vector2.Lerp (size, sdest, speed);
+            }
+        }
+
+        IEnumerator E_Destroy (RectTransform animatedElement) {
+            var t = 0f;
+            CanvasGroup cg = null;
+            if (DestroyAnim == DestroyAnimType.FadeOut || DestroyAnim == DestroyAnimType.ScaleAndFade) {
+                cg = animatedElement.GetComponent<CanvasGroup> ();
+                if (cg == null) {
+                    cg = animatedElement.gameObject.AddComponent<CanvasGroup> ();
+                    cg.alpha = 1f;
+                }
+            }
+            while (t < 1f) {
+                var speed = AnimationSpeed * Time.deltaTime;
+                if (DestroyAnim == DestroyAnimType.ScaleDown || DestroyAnim == DestroyAnimType.ScaleAndFade) {
+                    animatedElement.localScale = Vector3.Lerp (animatedElement.localScale, Vector3.zero, speed);
+                }
+                if (cg != null) {
+                    cg.alpha = Mathf.Lerp (cg.alpha, 0f, speed);
+                }
+                t += Time.deltaTime;
+                yield return null;
+            }
+            Destroy (animatedElement.gameObject);
+        }
+
+        /// <summary>
+        /// Add an existing element to the end of the layout group with smooth interpolation
+        /// </summary>
+        public void AddElement (Object element) {
+            if (element is GameObject go) {
+                AddElement (go);
+            } else if (element is Component c) {
+                AddElement (c.gameObject);
+            }
+        }
+
+        /// <summary>
+        /// Insert an existing element at the top of the layout group with smooth interpolation
+        /// </summary>
+        public void InsertElement (Object element) {
+            if (element is GameObject go) {
+                AddElement (go, siblingIndex: 0);
+            } else if (element is Component c) {
+                AddElement (c.gameObject, siblingIndex: 0);
+            }
+        }
+
+        /// <summary>
+        /// Add an existing element to the layout group with smooth interpolation. Optionally set siblingIndex directly. Returns the animated element's RectTransform
+        /// </summary>
+        public RectTransform AddElement (GameObject element, int siblingIndex = -1) {
+            var rt = element.GetComponent<RectTransform> ();
+            if (!TrackedTransforms.Add (rt))
+                return null;
+            var pos = rt.position;
+            rt.SetParent (transform, worldPositionStays: false);
+            if (siblingIndex >= 0) {
+                rt.SetSiblingIndex (siblingIndex);
+            }
+            //new element, lets clone it and track it
+            var newGameObject = Instantiate (rt.gameObject, Container);
+            var tuple = new Tuple {
+                original = rt,
+                animated = newGameObject.GetComponent<RectTransform> (),
+            };
+            tuple.animated.position = pos;
+            TrackedObjects.Add (tuple);
+            return tuple.animated;
+        }
+    }
+
+}

--- a/Runtime/LayoutAnimator.cs
+++ b/Runtime/LayoutAnimator.cs
@@ -48,7 +48,9 @@ namespace CineGame.MobileComponents {
         }
 
         void OnDestroy () {
-            Destroy (Container.gameObject);
+            if (Container != null) {
+                Destroy (Container.gameObject);
+            }
         }
 
         void OnTransformChildrenChanged () {

--- a/Runtime/LayoutAnimator.cs
+++ b/Runtime/LayoutAnimator.cs
@@ -34,6 +34,7 @@ namespace CineGame.MobileComponents {
 
         void Start () {
             var containerGo = Instantiate (gameObject, transform.parent);
+            containerGo.name = "LayoutAnimator_" + containerGo.name;
             Container = containerGo.transform;
             Destroy (containerGo.GetComponent<LayoutAnimator> ());
             Destroy (containerGo.GetComponent<LayoutGroup> ());

--- a/Runtime/LayoutAnimator.cs
+++ b/Runtime/LayoutAnimator.cs
@@ -22,6 +22,7 @@ namespace CineGame.MobileComponents {
 
         Transform Container;
         bool bCheckAdded;
+        RectTransform MyRectTransform;
 
         class Tuple {
             public RectTransform original;
@@ -39,6 +40,7 @@ namespace CineGame.MobileComponents {
             var layoutElement = containerGo.AddComponent<LayoutElement> ();
             layoutElement.ignoreLayout = true;
             GetComponent<CanvasGroup> ().alpha = 0f;
+            MyRectTransform = GetComponent<RectTransform> ();
             //var containerGo = new GameObject ("LayoutAnimator_Container");
             //containerGo.transform.SetParent (GetComponentInParent<Canvas> ().transform);
             //Container = containerGo.AddComponent<RectTransform> ();
@@ -156,6 +158,7 @@ namespace CineGame.MobileComponents {
                 animated = newGameObject.GetComponent<RectTransform> (),
             };
             tuple.animated.position = pos;
+            LayoutRebuilder.ForceRebuildLayoutImmediate (MyRectTransform);
             TrackedObjects.Add (tuple);
             return tuple.animated;
         }

--- a/Runtime/LayoutAnimator.cs.meta
+++ b/Runtime/LayoutAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c11e6438a22d14a119c26a450b02d98e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: efec9089586ac4574995396036ef8524, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.cinegamesdk.mobile",
-    "version": "1.6.3",
+    "version": "1.7.0",
     "displayName": "CineGame Mobile SDK",
     "description": "This is the SDK for creating mobile interfaces for CineGame and CineClash",
     "unity": "2019.4",


### PR DESCRIPTION
This PR adds a new component to the SDK which allows for smooth animation of Unity UI's LayoutGroups (eg _Vertical Layout Group_)

The component is added to the LayoutGroup which should animate as elements are added, reordered or removed. 

The component automatically keeps track of child elements, but if you want to smoothly add an existing element from outside the LayoutGroup (reparenting), you can invoke the AddElement or InsertElement methods which will smoothly interpolate from the element's current position to its new position in the LayoutGroup.
