### PR TITLE
Updated URL for Profanity API following naming convention

### DIFF
--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.8.0.0")]
+[assembly: AssemblyVersion ("1.9.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("1.8.0.0")]
+[assembly: AssemblyVersion ("1.9.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Runtime/Util.cs
+++ b/Runtime/Util.cs
@@ -248,7 +248,12 @@ namespace CineGame.MobileComponents {
 
 
 		public static string GetRegionProfanityUrl () {
-			return $"https://profanity.cinemataztic.com/{Markets [GetRegion ()].MarketID}/txt-file";
+			var market = Markets [GetRegion()];
+			var uri = new Uri ($"https://{market.Network}-{market.Country}.api.profanity.{market.Cluster}.cinemataztic.com/txt-file");
+			if (isStaging || isDev) {
+				return new Uri (Regex.Replace (uri.AbsoluteUri, "(.+?)\\.[^.]+?\\.(cinemataztic\\.com.+)", isStaging ? "$1.staging.$2" : "$1.dev.$2"));
+			}
+			return uri;
 		}
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.cinegamesdk.mobile",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "displayName": "CineGame Mobile SDK",
     "description": "This is the SDK for creating mobile interfaces for CineGame and CineClash",
     "unity": "2021.3",


### PR DESCRIPTION
Ready for when the new profanity-api version hits production